### PR TITLE
fix: Starlight設定読み込みエラーの修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-import starlightConfig from './src/starlight.config';
+import { SITE_TITLE, SITE_DESCRIPTION, REPO_URL } from './src/config';
 
 // https://astro.build/config
 export default defineConfig({
@@ -22,6 +22,54 @@ export default defineConfig({
   
   // Starlightインテグレーションを追加
   integrations: [
-    starlight(starlightConfig),
+    starlight({
+      title: SITE_TITLE,
+      description: SITE_DESCRIPTION,
+      
+      // URL to GitHub repository
+      social: {
+        github: REPO_URL,
+      },
+      
+      // Default locale for the site
+      defaultLocale: 'ja',
+      
+      // Configure sidebar navigation
+      sidebar: [
+        {
+          label: 'ホーム',
+          link: '/',
+        },
+        {
+          label: 'カテゴリー',
+          items: [
+            { label: 'すべてのページ', link: '/pages' },
+            { label: 'ドキュメント', link: '/category/documentation' },
+            { label: 'チュートリアル', link: '/category/tutorial' },
+            { label: 'Wiki', link: '/category/wiki' },
+          ],
+        },
+        {
+          label: 'リソース',
+          items: [
+            { label: 'GitHub', link: REPO_URL },
+            { label: 'Issue作成', link: `${REPO_URL}/issues/new` },
+          ],
+        },
+      ],
+      
+      // Customize the sidebar behavior
+      customCss: [
+        // Starlightのデフォルトスタイルを拡張するカスタムCSS
+        './src/styles/custom.css',
+      ],
+      
+      // Enable search functionality
+      components: {
+        // ヘッダーとフッターのカスタムコンポーネントをオーバーライド
+        Head: './src/components/CustomHead.astro',
+        Footer: './src/components/CustomFooter.astro',
+      },
+    }),
   ],
 });


### PR DESCRIPTION
## エラー修正

このプルリクエストでは、以前のPR #7でマージしたStarlight統合設定に関するエラーを修正しています。

### 修正内容

- `astro.config.mjs` ファイルの設定方法を変更
- 外部設定ファイルからの読み込みをやめ、直接設定を記述する形に修正
- Starlightの設定を `starlight()` 関数に直接渡すように変更

### エラー詳細

```
Missing "./config" specifier in "@astrojs/starlight" package
```

このエラーはStarlightの設定ファイルの読み込み方法が原因で発生していました。Starlightは外部ファイルからの設定読み込みをこの形式ではサポートしていないため、設定を直接astro.config.mjsファイルに記述することで解決しました。

### テスト

ローカル環境でビルドが正常に完了することを確認済みです。