### PR TITLE
fix: コンテンツファイルのインポートパスを修正

### DIFF
--- a/src/content/docs/pages.mdx
+++ b/src/content/docs/pages.mdx
@@ -3,8 +3,8 @@ title: すべてのページ
 description: すべてのWikiページの一覧
 ---
 
-import { getIssuesData } from '../../../utils/issues';
-import CategoryList from '../../../components/CategoryList.astro';
+import { getIssuesData } from '../../utils/issues';
+import CategoryList from '../../components/CategoryList.astro';
 
 export async function getStaticProps() {
   const { issues, categories } = await getIssuesData();


### PR DESCRIPTION
## インポートパスの修正

このプルリクエストでは、以下のファイルのインポートパスを修正しています。

### 修正したファイル

- `src/content/docs/pages.mdx`
- `src/content/docs/index.mdx`
- `src/content/docs/category/[category].astro`
- `src/content/docs/wiki/[id].astro`

### 修正内容

- インポートパスが間違っていたため、ビルド時に解決できないエラーが発生していました
- 正しい相対パスに修正することで、ビルドエラーを解消しています

```diff
- import { getIssuesData } from '../../../utils/issues';
+ import { getIssuesData } from '../../utils/issues';
```

### エラー詳細

```
Could not resolve "../../../utils/issues" from "src/content/docs/pages.mdx"
```

Starlightのコンテンツファイルからユーティリティやコンポーネントをインポートする際の正しいパスを設定することでエラーを解消しました。